### PR TITLE
Setting path to training script

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -8,6 +8,33 @@ export CUDA_VISIBLE_DEVICES=$1
 export CANDLE_DATA_DIR=$2
 export CANDLE_CONFIG=$3
 
+# Check if path to model directory is set otherwise assume this scriot is in top level of model dir
+if [ -z $MODEL_DIR ]
+then
+        MODEL_DIR=$( dirname -- "$0"; )
+fi
+
+# Check if directory exists
+if ! [ -d $MODEL_DIR ]
+then
+        echo No directory $MODEL_DIR
+        exit 404
+fi
+
+if ! [ -d $CANDLE_DATA_DIR && -w $CANDLE_DATA_DIR ]
+then
+        echo No directory $CANDLE_DATA_DIR or not writable
+        exit 404
+fi
+
+
+
+
+
+# Change into directory and execute tests
+cd ${MODEL_DIR}
 python HiDRA_FeatureGeneration.py
 python HiDRA_training.py
 
+# Check if successful 
+exit 0


### PR DESCRIPTION
Path to scripts in model dir wasn't set. In order for test.sh to work you had to execute it from within the model directory next to the training scripts. This did not work for executing the script from a container. The scripts is in the search path of the container. 